### PR TITLE
feat: adds loginkey so we can do `nino config loginkey`

### DIFF
--- a/src/App/Console/ConfigCommand.php
+++ b/src/App/Console/ConfigCommand.php
@@ -67,6 +67,14 @@ class ConfigCommand extends Command
             return Command::SUCCESS;
         }
 
+		// loginkey
+		if ( 'loginkey' === $config_task ) {
+			// Adds login secret.
+	        $this->filesystem->appendToFile( $this->root_dir_path . '/.env', self::autoLoginSecret() );
+
+			return Command::SUCCESS;
+		}
+
         if ( false === $config_task ) {
             $output->writeln( "<info>Config Setup for:$this->root_dir_path</info>" );
 

--- a/src/inc/app.php
+++ b/src/inc/app.php
@@ -361,4 +361,12 @@ return [
     'publickey'        => [
         'app-key' => env( 'WEB_APP_PUBLIC_KEY', null ),
     ],
+
+	/**
+	 * Defines the public key directory.
+	 *
+	 * This is the directory where we store out public key files.
+	 * the directory here is relative to the application root path
+	 */
+	'publickey_dir' => 'publickeys',
 ];


### PR DESCRIPTION
'config' command to generate autologin secrets. This commit adds a new 'config' command, enabling the generation of a  fresh autologin secret for the env file via the command 'php nino config  loginkey'. It's crucial to emphasize that this addition does not remove  the existing key.